### PR TITLE
Added set tags to Create a new address book

### DIFF
--- a/modoboa_contacts/lib/carddav.py
+++ b/modoboa_contacts/lib/carddav.py
@@ -174,10 +174,12 @@ class PyCardDAV(object):
         self._check_write_support()
         data = (
             Mkcol() + [
-                elements.dav.Prop() + [
-                    elements.dav.ResourceType() +
-                    elements.dav.Collection() +
-                    AddressBook()
+                 elements.dav.Set() + [
+                    elements.dav.Prop() + [
+                        elements.dav.ResourceType() +
+                        elements.dav.Collection() +
+                        AddressBook()
+                    ]
                 ]
             ]
         )


### PR DESCRIPTION
Without the set tag the address book fails to create, this means trying to enable sync on a users contacts (Settings > Pref > "Synchonize address book using CardDAV") fails with a 500 error on the frontend and a 403 from radicale.